### PR TITLE
improve section UI and add collapse effect

### DIFF
--- a/resources/views/infolists/components/activity-section.blade.php
+++ b/resources/views/infolists/components/activity-section.blade.php
@@ -35,14 +35,14 @@
                 @endphp
 
 
-                <div x-show="@js($index) < totalShowItemsCount" :key="@js(rand())"
+                <div x-show="@js($index) < totalShowItemsCount" x-collapse :key="@js(rand())"
                     @class(['flex flex-col'])>
 
                     <div class="flex gap-x-3">
 
                         <div @class([
                             'relative last:after:hidden',
-                            'after:absolute after:top-7 after:bottom-0 after:start-4 after:w-px after:-translate-x-[0.5px] after:bg-gray-300 dark:after:bg-gray-700' => !$loop->last,
+                            'after:absolute after:top-8 after:bottom-0 after:start-4 after:w-px after:-translate-x-[0.5px] after:bg-gray-300 dark:after:bg-gray-700' => !$loop->last,
                         ])>
                             {{ $activityIcon }}
                         </div>
@@ -80,7 +80,7 @@
                     $color = $getShowItemsColor();
                 @endphp
                 <x-filament::link x-on:click="totalShowItemsCount += showItemsCount" :icon="$icon" :color="$color"
-                    class="cursor-pointer hover:underline">
+                    class="ms-1.5 cursor-pointer hover:underline">
                     {{ $label }}
                 </x-filament::link>
             </div>


### PR DESCRIPTION
small improvements, to fix some UI and add `x-collapse` to the (show more) button

the changes in CSS:
fix the vertical line alignment, and make the (show more) button aligned with the  vertical line
before:
<img width="573" alt="Screenshot 2024-01-20 at 3 21 12 PM" src="https://github.com/199ocero/activity-timeline/assets/1952412/38fc26a0-2396-4d64-9d59-8b9e23efae3e">

after:
<img width="573" alt="Screenshot 2024-01-20 at 3 20 53 PM" src="https://github.com/199ocero/activity-timeline/assets/1952412/95dbe262-6203-45ae-b2a8-cb2fd92920be">


the collapse effect:
making the transition smother

https://github.com/199ocero/activity-timeline/assets/1952412/e9ec917a-a1a2-4ae8-9ca3-97eb27c9182f

