### PR TITLE
add support to pass any `extraAttributes`

### DIFF
--- a/resources/views/components/section.blade.php
+++ b/resources/views/components/section.blade.php
@@ -1,10 +1,17 @@
-@props(['heading', 'description' => null, 'aside' => true])
+@props(['heading', 'description' => null, 'aside' => true, 'extraAttributes' => []])
 
-<section @class([
-    'fi-timeline-section',
-    'bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10' => !$aside,
-    'grid items-start grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-3' => $aside,
-])>
+<section
+    {{
+        $attributes
+            ->merge($extraAttributes, escape: false)
+            ->class([
+                'fi-timeline-section',
+                match (true) {
+                    !$aside => 'bg-white shadow-sm rounded-xl ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10',
+                    $aside => 'grid items-start grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-3',
+                },
+            ])
+    }}>
     <header @class([
         'fi-timeline-section-header',
         'flex flex-col gap-3 px-6 py-4 overflow-hidden sm:flex-row sm:items-center' => !$aside,

--- a/resources/views/infolists/components/activity-section.blade.php
+++ b/resources/views/infolists/components/activity-section.blade.php
@@ -1,4 +1,4 @@
-<x-activity-timeline::section :aside="$isAside()">
+<x-activity-timeline::section :aside="$isAside()" :extraAttributes="$getExtraAttributes()">
     <x-slot name="heading">
         {{ $getLabel() ?? $getHeading() }}
     </x-slot>


### PR DESCRIPTION
now we can add custom classes like

```php
ActivitySection::make('activities')
    ->extraAttributes(['class'=>'my-new-class'])
```

this useful if I am overwriting the default classes and using the component in multiple area of my app