### PR TITLE
Add support for tooltips for the `ActivityDate` entry

### DIFF
--- a/resources/views/infolists/components/activity-date.blade.php
+++ b/resources/views/infolists/components/activity-date.blade.php
@@ -1,3 +1,15 @@
-<span class="flex-shrink-0 text-xs font-medium text-gray-500 uppercase fi-timeline-item-date dark:text-gray-400">
+@php
+    $tooltip = $getTooltip();
+@endphp
+
+<span
+    @if (filled($tooltip))
+        x-data="{}"
+        x-tooltip="{
+                content: @js($tooltip),
+                theme: $store.theme,
+            }"
+    @endif
+    class="flex-shrink-0 text-xs font-medium text-gray-500 uppercase fi-timeline-item-date dark:text-gray-400">
     {{ $getState() != null ? $getDate($getState()) : $getPlaceholder() }}
 </span>

--- a/src/Components/ActivityDate.php
+++ b/src/Components/ActivityDate.php
@@ -28,6 +28,10 @@ class ActivityDate extends Entry
 
     public function getDate($value): ?string
     {
+        if ($this->getStateUsing !== null) {
+            return $this->getState();
+        }
+
         $date = Carbon::parse($value)
             ->setTimezone($this->getTimezone());
 


### PR DESCRIPTION
1. Adds support for tooltips to the date template (I can add support for the rest of the entries if needed)
1. Allows overriding the date field when a user supplies a `getStateUsing` closure to allow custom values for that part of the activity log. However, this is probably a breaking change so I'm open to suggestions on how to implement this.

![image](https://github.com/199ocero/activity-timeline/assets/145474359/2efc639d-82b6-4060-9462-6058068baab6)
