### PR TITLE
Fix formatting of null values

### DIFF
--- a/src/Concerns/HasSetting.php
+++ b/src/Concerns/HasSetting.php
@@ -141,6 +141,14 @@ trait HasSetting
         return $activities;
     }
 
+    private static function formatValue($value)
+    {
+        if ($value === null) return '—';
+        if (is_array($value)) return json_encode($value);
+
+        return $value;
+    }
+
     private function modifiedState(): array
     {
         return [
@@ -169,14 +177,10 @@ trait HasSetting
                         $changes = [];
 
                         foreach ($newValues as $key => $newValue) {
-                            $oldValue = is_array($oldValues[$key]) ? json_encode($oldValues[$key]) : $oldValues[$key] ?? '-';
-                            $newValue = $newValue ?? '—';
+                            $oldValue = self::formatValue($oldValues[$key] ?? null);
+                            $newValue = self::formatValue($newValue);
 
-                            if (is_array($newValue)) {
-                                $newValue = json_encode($newValue);
-                            }
-
-                            if (isset($oldValue) && $oldValue != $newValue) {
+                            if ($oldValue != $newValue) {
                                 $changes[] = "- {$key} from <strong>".htmlspecialchars($oldValue).'</strong> to <strong>'.htmlspecialchars($newValue).'</strong>';
                             }
                         }


### PR DESCRIPTION
Currently, null in an old value is formatted to U+002D HYPHEN-MINUS, while null in a new value is formatted to U+2014 EM DASH. These are not the same, so properties would show up as being changed if they were null and unchanged. This fixes this by doing the formatting in one place, thus standardizing on the U+2014 EM DASH option.

This was broken in [this commit](https://github.com/199ocero/activity-timeline/commit/dd5e58ca1e10f9442d7625867bd28fd9b3ee62ad), which appears to have accidentally changed one of the em-dashes to a hyphen.